### PR TITLE
Fix use-before-initialization bug in gdbcontroller

### DIFF
--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -109,6 +109,8 @@ class GdbController():
 
         if not mi_cmd_to_write.endswith('\n'):
             mi_cmd_to_write_nl = mi_cmd_to_write + '\n'
+        else:
+            mi_cmd_to_write_nl = mi_cmd_to_write
 
         if True:
             # select not implemented in windows for pipes


### PR DESCRIPTION
Occurs when `GdbController.write` is called with a string ending in `\n`.