### PR TITLE
Use codecs.open() to open the readme.rst, to prevent locale related bugs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 import sys
 import re
+from codecs import open
 from setuptools import find_packages, setup, Command
 from pygdbmi.tests import test_app
 
 EXCLUDE_FROM_PACKAGES = []
 
-readme = open('README.rst', 'r').read()
+readme = open('README.rst', 'rb', 'utf-8').read()
 
 with open('pygdbmi/__init__.py', 'r') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',


### PR DESCRIPTION
Python3 uses locale.getpreferredencoding(False) for opening files when 'encoding' is not given as argument. This makes setup.py fail on systems without utf-8 locale configured, as the saythanks.io badge uses an unicode symbol.
This PR contains a py2 and py3 compatible workaround, utilizing the encodings module to open the readme-file explicitly utf-8 encoded.