### PR TITLE
Wait for gdb-process to actually terminate upon exit()

### DIFF
--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -359,6 +359,7 @@ class GdbController():
         Returns: None"""
         if self.gdb_process:
             self.gdb_process.terminate()
+            self.gdb_process.communicate()
         self.gdb_process = None
         return None
 


### PR DESCRIPTION
Hi!

It seems that subprocess.terminate() in python2.7 can cause the terminal to be messed up in certain corner cases. (Mainly experienced by us in multi-threaded python-scripts, when the termination of the python-script is close to the termination of the gdbprocess.)

Under the hood, terminate() just sends SIGTERM to the underlying process, and we believe that this may cause a race condition between subprocess termination and python script termination, leading to this messup iin case the subprocess is terminating after the main python script.

One fix which worked for us is to call subprocess.wait() after subprocess.terminate(), as this will wait for the subprocess to actually terminate.