### PR TITLE
Fixed utf8 decoding error while gdb outputs invalid data

### DIFF
--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -361,7 +361,7 @@ class GdbController:
         if not raw_output:
             return responses
         response_list = list(
-            filter(lambda x: x, raw_output.decode().split("\n"))
+            filter(lambda x: x, raw_output.decode(errors="replace").split("\n"))
         )  # remove blank lines
 
         # parse each response from gdb into a dict, and store in a list


### PR DESCRIPTION
While using pygdbmi I came across situation during which gdb outputs trash form invalid pointer and decode() function tries to parse it as utf8. 