### PR TITLE
Remove NoGdbProcessError from docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # pygdbmi release history
 
+## 0.10.0.1
+* Update docs
+
 ## 0.10.0.0
 
  **Breaking Changes**

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -230,7 +230,6 @@ class IoManager:
         Returns:
             List of parsed gdb responses if read_response is True, otherwise []
         Raises:
-            NoGdbProcessError: if there is no gdb subprocess running
             TypeError: if mi_cmd_to_write is not valid
         """
         # self.verify_valid_gdb_subprocess()


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes
Fixed docstring of `IoManager.write` by removing `NoGdbProcessError`, which can no longer get raised.