### PR TITLE
Fixes issue # 54: `IoManager._get_responses_windows` mangles token when reading from stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pygdbmi release history
 
+## 0.10.0.1
+
+Refactored IOManager non-blocking reading for Windows. Fixes issue #54 : "`IoManager._get_responses_windows` mangles token when reading from stdout"
+
 ## 0.10.0.0
 
  **Breaking Changes**

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -17,6 +17,15 @@ from pygdbmi.constants import (
     GdbTimeoutError,
 )
 
+import sys
+from subprocess import PIPE, Popen
+from threading  import Thread
+
+try:
+    from queue import Queue, Empty
+except ImportError:
+    from Queue import Queue, Empty  # python 2.x
+
 if USING_WINDOWS:
     import msvcrt
     from ctypes import windll, byref, wintypes, WinError, POINTER  # type: ignore
@@ -25,6 +34,7 @@ else:
     import fcntl
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 class IoManager:
@@ -61,13 +71,22 @@ class IoManager:
         self._allow_overwrite_timeout_times = (
             self.time_to_check_for_additional_output_sec > 0
         )
-        make_non_blocking(self.stdout)
-        if self.stderr:
-            make_non_blocking(self.stderr)
 
-        # Sometimes stdout.readline() would mangle the data read from GDB.
-        # That's fixed if we pause a little.
-        self._response_windows_delay = 0.02
+        if USING_WINDOWS:
+            self.queue_stdout = Queue()
+            self.thread_stdout = Thread(target=enqueue_output, args=(self.stdout, self.queue_stdout))
+            self.thread_stdout.daemon = True # thread dies with the program
+            self.thread_stdout.start()
+
+            if self.stderr:
+                self.queue_stderr = Queue()
+                self.thread_stderr = Thread(target=enqueue_output, args=(self.stderr, self.queue_stderr))
+                self.thread_stderr.daemon = True # thread dies with the program
+                self.thread_stderr.start()
+        else:
+            fcntl.fcntl(self.stdout, fcntl.F_SETFL, os.O_NONBLOCK)
+            if self.stderr:
+                fcntl.fcntl(self.stderr, fcntl.F_SETFL, os.O_NONBLOCK)
 
     def get_gdb_response(
         self, timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC, raise_error_on_timeout=True
@@ -111,18 +130,17 @@ class IoManager:
         responses = []
         while True:
             responses_list = []
+
             try:
-                self.stdout.flush()
-                raw_output = self.stdout.readline().replace(b"\r", b"\n")
+                raw_output = self.queue_stdout.get_nowait()
                 responses_list = self._get_responses_list(raw_output, "stdout")
-            except IOError:
+            except Empty:
                 pass
 
             try:
-                self.stderr.flush()
-                raw_output = self.stderr.readline().replace(b"\r", b"\n")
+                raw_output = self.queue_stderr.get_nowait()
                 responses_list += self._get_responses_list(raw_output, "stderr")
-            except IOError:
+            except Empty:
                 pass
 
             responses += responses_list
@@ -135,9 +153,6 @@ class IoManager:
                 )
             elif time.time() > timeout_time_sec:
                 break
-
-            time.sleep(self._response_windows_delay)
-
         return responses
 
     def _get_responses_unix(self, timeout_sec):
@@ -326,29 +341,7 @@ def _buffer_incomplete_responses(
 
     return (raw_output, buf)
 
-
-def make_non_blocking(file_obj: io.IOBase):
-    """make file object non-blocking
-    Windows doesn't have the fcntl module, but someone on
-    stack overflow supplied this code as an answer, and it works
-    http://stackoverflow.com/a/34504971/2893090"""
-
-    if USING_WINDOWS:
-        LPDWORD = POINTER(DWORD)
-        PIPE_NOWAIT = wintypes.DWORD(0x00000001)
-
-        SetNamedPipeHandleState = windll.kernel32.SetNamedPipeHandleState
-        SetNamedPipeHandleState.argtypes = [HANDLE, LPDWORD, LPDWORD, LPDWORD]
-        SetNamedPipeHandleState.restype = BOOL
-
-        h = msvcrt.get_osfhandle(file_obj.fileno())
-
-        res = windll.kernel32.SetNamedPipeHandleState(h, byref(PIPE_NOWAIT), None, None)
-        if res == 0:
-            raise ValueError(WinError())
-
-    else:
-        # Set the file status flag (F_SETFL) on the pipes to be non-blocking
-        # so we can attempt to read from a pipe with no new data without locking
-        # the program up
-        fcntl.fcntl(file_obj, fcntl.F_SETFL, os.O_NONBLOCK)
+def enqueue_output(out, queue):
+    for line in iter(out.readline, b''):
+        queue.put(line.replace(b"\r", b"\n"))
+    out.close()

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -65,6 +65,10 @@ class IoManager:
         if self.stderr:
             make_non_blocking(self.stderr)
 
+        # Sometimes stdout.readline() would mangle the data read from GDB.
+        # That's fixed if we pause a little.
+        self._response_windows_delay = 0.02
+
     def get_gdb_response(
         self, timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC, raise_error_on_timeout=True
     ):
@@ -131,7 +135,8 @@ class IoManager:
                 )
             elif time.time() > timeout_time_sec:
                 break
-            time.sleep(0.01)
+
+            time.sleep(self._response_windows_delay)
 
         return responses
 

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -344,4 +344,4 @@ def _buffer_incomplete_responses(
 def enqueue_output(out, queue):
     for line in iter(out.readline, b''):
         queue.put(line.replace(b"\r", b"\n"))
-    out.close()
+    # Not necessary to close, it will be done in the main process.

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -34,8 +34,6 @@ else:
     import fcntl
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
 
 class IoManager:
     def __init__(

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -18,11 +18,7 @@ from pygdbmi.constants import (
 )
 
 from threading import Thread
-
-try:
-    from queue import Queue, Empty
-except ImportError:
-    from Queue import Queue, Empty  # python 2.x
+from queue import Queue, Empty
 
 if not USING_WINDOWS:
     import fcntl
@@ -66,7 +62,7 @@ class IoManager:
         )
 
         if USING_WINDOWS:
-            self.queue_stdout = Queue()
+            self.queue_stdout = Queue()  # type: Queue
             self.thread_stdout = Thread(
                 target=enqueue_output, args=(self.stdout, self.queue_stdout)
             )
@@ -74,7 +70,7 @@ class IoManager:
             self.thread_stdout.start()
 
             if self.stderr:
-                self.queue_stderr = Queue()
+                self.queue_stderr = Queue()  # type: Queue
                 self.thread_stderr = Thread(
                     target=enqueue_output, args=(self.stderr, self.queue_stderr)
                 )

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -19,7 +19,7 @@ from pygdbmi.constants import (
 
 import sys
 from subprocess import PIPE, Popen
-from threading  import Thread
+from threading import Thread
 
 try:
     from queue import Queue, Empty
@@ -34,6 +34,7 @@ else:
     import fcntl
 
 logger = logging.getLogger(__name__)
+
 
 class IoManager:
     def __init__(
@@ -72,14 +73,18 @@ class IoManager:
 
         if USING_WINDOWS:
             self.queue_stdout = Queue()
-            self.thread_stdout = Thread(target=enqueue_output, args=(self.stdout, self.queue_stdout))
-            self.thread_stdout.daemon = True # thread dies with the program
+            self.thread_stdout = Thread(
+                target=enqueue_output, args=(self.stdout, self.queue_stdout)
+            )
+            self.thread_stdout.daemon = True  # thread dies with the program
             self.thread_stdout.start()
 
             if self.stderr:
                 self.queue_stderr = Queue()
-                self.thread_stderr = Thread(target=enqueue_output, args=(self.stderr, self.queue_stderr))
-                self.thread_stderr.daemon = True # thread dies with the program
+                self.thread_stderr = Thread(
+                    target=enqueue_output, args=(self.stderr, self.queue_stderr)
+                )
+                self.thread_stderr.daemon = True  # thread dies with the program
                 self.thread_stderr.start()
         else:
             fcntl.fcntl(self.stdout, fcntl.F_SETFL, os.O_NONBLOCK)
@@ -284,9 +289,7 @@ class IoManager:
         for fileno in outputready:
             if fileno == self.stdin_fileno:
                 # ready to write
-                self.stdin.write(  # type: ignore
-                    mi_cmd_to_write_nl.encode()
-                )
+                self.stdin.write(mi_cmd_to_write_nl.encode())  # type: ignore
                 # must flush, otherwise gdb won't realize there is data
                 # to evaluate, and we won't get a response
                 self.stdin.flush()  # type: ignore
@@ -339,7 +342,8 @@ def _buffer_incomplete_responses(
 
     return (raw_output, buf)
 
+
 def enqueue_output(out, queue):
-    for line in iter(out.readline, b''):
+    for line in iter(out.readline, b""):
         queue.put(line.replace(b"\r", b"\n"))
     # Not necessary to close, it will be done in the main process.

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -131,6 +131,7 @@ class IoManager:
                 )
             elif time.time() > timeout_time_sec:
                 break
+            time.sleep(0.01)
 
         return responses
 

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -17,8 +17,6 @@ from pygdbmi.constants import (
     GdbTimeoutError,
 )
 
-import sys
-from subprocess import PIPE, Popen
 from threading import Thread
 
 try:
@@ -26,11 +24,7 @@ try:
 except ImportError:
     from Queue import Queue, Empty  # python 2.x
 
-if USING_WINDOWS:
-    import msvcrt
-    from ctypes import windll, byref, wintypes, WinError, POINTER  # type: ignore
-    from ctypes.wintypes import HANDLE, DWORD, BOOL
-else:
+if not USING_WINDOWS:
     import fcntl
 
 logger = logging.getLogger(__name__)

--- a/tests/test_pygdbmi.py
+++ b/tests/test_pygdbmi.py
@@ -188,7 +188,7 @@ class TestPyGdbMi(unittest.TestCase):
         assert response["stream"] == "stdout"
         assert response["token"] is None
 
-        responses = gdbmi.write(["-file-list-exec-source-files", "-break-insert main"])
+        responses = gdbmi.write(["-file-list-exec-source-files", "-break-insert main"], timeout_sec=3)
         assert len(responses) != 0
 
         responses = gdbmi.write(["-exec-run", "-exec-continue"], timeout_sec=3)
@@ -206,13 +206,8 @@ class TestPyGdbMi(unittest.TestCase):
         assert responses is None
         assert gdbmi.gdb_process is None
 
-        # Test NoGdbProcessError exception
-        got_no_process_exception = False
-        try:
-            responses = gdbmi.write("-file-exec-and-symbols %s" % c_hello_world_binary)
-        except IOError:
-            got_no_process_exception = True
-        assert got_no_process_exception is True
+        # Test ValueError exception
+        self.assertRaises(ValueError, gdbmi.write, "-file-exec-and-symbols %s" % c_hello_world_binary)
 
         # Respawn and test signal handling
         gdbmi.spawn_new_gdb_subprocess()

--- a/tests/test_pygdbmi.py
+++ b/tests/test_pygdbmi.py
@@ -188,7 +188,9 @@ class TestPyGdbMi(unittest.TestCase):
         assert response["stream"] == "stdout"
         assert response["token"] is None
 
-        responses = gdbmi.write(["-file-list-exec-source-files", "-break-insert main"], timeout_sec=3)
+        responses = gdbmi.write(
+            ["-file-list-exec-source-files", "-break-insert main"], timeout_sec=3
+        )
         assert len(responses) != 0
 
         responses = gdbmi.write(["-exec-run", "-exec-continue"], timeout_sec=3)
@@ -207,7 +209,9 @@ class TestPyGdbMi(unittest.TestCase):
         assert gdbmi.gdb_process is None
 
         # Test ValueError exception
-        self.assertRaises(ValueError, gdbmi.write, "-file-exec-and-symbols %s" % c_hello_world_binary)
+        self.assertRaises(
+            ValueError, gdbmi.write, "-file-exec-and-symbols %s" % c_hello_world_binary
+        )
 
         # Respawn and test signal handling
         gdbmi.spawn_new_gdb_subprocess()


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

Fixes issue #54 

Removed the `make_non_blocking` function. Refactored the `_get_responses_windows` method to use separate threads and queues to make reading non-blocking. solution based on [this StackOverflow answer](https://stackoverflow.com/a/4896288/6271889)

## Test plan
Executed unit tests:

```
$ python test_pygdbmi.py
....
----------------------------------------------------------------------
Ran 4 tests in 8.774s

OK
```
