### PR TITLE
Unescape MI strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # pygdbmi release history
 
+## dev
+* Strings containing escapes are now unescaped, both for messages in error records, which were previously mangled (#57), and textual records, which were previously left escaped (#58)
+
 ## 0.10.0.1
 * Fix bug with `time_to_check_for_additional_output_sec`, as it was not being used when passed to `GdbController`
 

--- a/pygdbmi/gdbescapes.py
+++ b/pygdbmi/gdbescapes.py
@@ -1,0 +1,214 @@
+"""
+Support for unescaping strings produced by GDB MI.
+"""
+
+import re
+from typing import Iterator, Tuple
+
+
+def unescape(escaped_str: str) -> str:
+    """Unescape a string escaped by GDB in MI mode.
+
+    Args:
+        escaped_str: String to unescape (without initial and final double quote).
+
+    Returns:
+        The strings with escape codes transformed into normal characters.
+    """
+    unescaped_str, after_string_index = _unescape_internal(
+        escaped_str, expect_closing_quote=False
+    )
+    assert after_string_index == -1, (
+        f"after_string_index is {after_string_index} but it was "
+        "expected to be -1 as expect_closing_quote is set to False"
+    )
+    return unescaped_str
+
+
+def advance_past_string_with_gdb_escapes(
+    escaped_str: str, *, start: int = 0
+) -> Tuple[str, int]:
+    """Unescape a string escaped by GDB in MI mode, and find the double quote
+    terminating it.
+
+    Args:
+        escaped_str: String to unescape (without initial double quote).
+        start: the position in escaped_str at which to start unescaping the string
+
+    Returns:
+        A tuple containing the unescaped string and the index in escaped_str just after
+        the escape string (that is, escaped_str[start-1] is always the closing double
+        quote and escaped_str[start:] is the portion of escaped_str after the escaped
+        string).
+    """
+    return _unescape_internal(escaped_str, expect_closing_quote=True, start=start)
+
+
+# Regular expression matching both escapes and unescaped quotes in GDB MI escaped
+# strings.
+_ESCAPES_RE = re.compile(
+    r"""
+    # Match all text before an escape or quote so it can be preserved as is.
+    (?P<before>
+        .*?
+    )
+    # Match either an escape or an unescaped quote.
+    (
+        (
+            # All escapes start with a backslash...
+            \\
+            # ... and are followed by either a 3-digit octal number or a single
+            # character for common escapes. See _GDB_MI_NON_OCTAL_ESCAPES for valid
+            # ones.
+            (
+                # Instead of matching a single octal escape we match multiple ones in a
+                # row.
+                # This is because a single Unicode character can be encoded as multiple
+                # escape sequences so, if we decoded the escape sequences one at a time,
+                # the resulting string would not be valid until all the bytes are
+                # converted.
+                # This could also be solved by converting the input string into bytes
+                # but that's much slower for long strings.
+                (?P<escaped_octal>
+                    # First octal number without backslash which we matched earlier.
+                    [0-7]{3}
+                    # Addional (and optional) octal numbers, including a backslash.
+                    (
+                        \\
+                        [0-7]{3}
+                    )*
+                )
+                |
+                (?P<escaped_char>.)
+            )
+        )
+        |
+        # Match an unescaped quote.
+        # If expect_closing_quote is true, then this means the string is finished.
+        # If false, then the quote should have been escaped.
+        (?P<unescaped_quote>")
+    )
+    """,
+    flags=re.VERBOSE,
+)
+
+# Map from single character escape codes allowed in GDB MI strings to the corresponding
+# unescaped value.
+_NON_OCTAL_ESCAPES = {
+    "'": "'",
+    "\\": "\\",
+    "a": "\a",
+    "b": "\b",
+    "e": "\033",
+    "f": "\f",
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    '"': '"',
+}
+
+
+def _unescape_internal(
+    escaped_str: str, *, expect_closing_quote: bool, start: int = 0
+) -> Tuple[str, int]:
+    """Common code for unescaping strings escaped by GDB in MI mode.
+
+    MI-mode escapes are similar to standard Python escapes but:
+    * "\\e" is a valid escape.
+    * "\\NNN" escapes use numbers represented in octal format.
+      For instance, "\\040" encodes character 0o40, that is character 32 in decimal,
+      that is a space.
+
+    For details, see printchar in gdb/utils.c in the binutils-gdb repo.
+
+    Args:
+        escaped_str: String to unescape
+        expect_closing_quote: If true the closing quote must be in escaped_str[start:].
+            Otherwise, no unescaped quote is allowed.
+        start: the position in escaped_str at which to start unescaping the string.
+
+    Returns:
+        A tuple containing the unescaped string and the index in escaped_str just after
+        the escape string, or -1 if expect_closing_quote is False.
+    """
+    # The _ESCAPES_RE expression only matches escapes or unescaped quotes, plus the
+    # preeeding part of the escaped string.
+    # This variable tracks the end of the last match so the portion of escaped_str after
+    # that is not lost.
+    unmatched_start_index = start
+
+    # Was the closing quote found?
+    # This can be true only if expect_closing_quote is true.
+    found_closing_quote = False
+
+    unescaped_parts = []
+    for match in _ESCAPES_RE.finditer(escaped_str, pos=start):
+        # Text before the match (and after any previous match).
+        unescaped_parts.append(match["before"])
+
+        escaped_octal = match["escaped_octal"]
+        escaped_char = match["escaped_char"]
+        unescaped_quote = match["unescaped_quote"]
+
+        _, unmatched_start_index = match.span()
+
+        if escaped_octal is not None:
+            # We found one or more octal escapes. These are in the form "NNN" or, for
+            # multiple characters in a row, "NNN\NNN\NNN[...]".
+            # escaped_octal is guaranteed to be in the correct format by _ESCAPES_RE.
+            octal_sequence_bytes = bytearray()
+            # Strip the backslashes and iterate over the octal codes 3 by 3.
+            for octal_number in _split_n_chars(escaped_octal.replace("\\", ""), 3):
+                # Convert the 3 digits into a single byte.
+                try:
+                    octal_sequence_bytes.append(int(octal_number, base=8))
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Invalid octal number {octal_number!r} in {escaped_str!r}"
+                    ) from exc
+            replaced = octal_sequence_bytes.decode("utf-8")
+
+        elif escaped_char is not None:
+            # We found a single escaped character.
+            try:
+                replaced = _NON_OCTAL_ESCAPES[escaped_char]
+            except KeyError as exc:
+                raise ValueError(
+                    f"Invalid escape character {escaped_char!r} in {escaped_str!r}"
+                ) from exc
+
+        elif unescaped_quote:
+            # We found an unescaped quote.
+            if not expect_closing_quote:
+                raise ValueError(f"Unescaped quote found in {escaped_str!r}")
+
+            # This is the ending quote, so stop processing.
+            found_closing_quote = True
+            break
+
+        else:
+            raise AssertionError(
+                f"This code should not be reached for string {escaped_str!r}"
+            )
+
+        unescaped_parts.append(replaced)
+
+    if not found_closing_quote:
+        if expect_closing_quote:
+            raise ValueError(f"Missing closing quote in {escaped_str!r}")
+
+        # Don't drop the part of the escaped string after the last escape.
+        unescaped_parts.append(escaped_str[unmatched_start_index:])
+        # With expect_closing_quote being false, the whole string must always be matched
+        # so unmatched_start_index is not useful so we set it to -1.
+        # (We could set it to len(unmatched_start_index) as well but we would not get
+        # any benefit from having it set to a correct value.)
+        unmatched_start_index = -1
+
+    return "".join(unescaped_parts), unmatched_start_index
+
+
+def _split_n_chars(s: str, n: int) -> Iterator[str]:
+    """Iterates over string s `n` characters at a time"""
+    for i in range(0, len(s), n):
+        yield s[i : i + n]

--- a/pygdbmi/gdbmiparser.py
+++ b/pygdbmi/gdbmiparser.py
@@ -14,6 +14,7 @@ from typing import Dict, Union
 
 from pygdbmi.printcolor import fmt_green
 from pygdbmi.StringStream import StringStream
+from pygdbmi.gdbescapes import unescape
 
 _DEBUG = False
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ def parse_response(gdb_mi_text: str) -> Dict:
     elif _GDB_MI_CONSOLE_RE.match(gdb_mi_text):
         match = _GDB_MI_CONSOLE_RE.match(gdb_mi_text)
         if match:
-            payload = match.groups()[0]
+            payload = unescape(match.groups()[0])
         else:
             payload = None
         return {
@@ -85,7 +86,7 @@ def parse_response(gdb_mi_text: str) -> Dict:
     elif _GDB_MI_LOG_RE.match(gdb_mi_text):
         match = _GDB_MI_LOG_RE.match(gdb_mi_text)
         if match:
-            payload = match.groups()[0]
+            payload = unescape(match.groups()[0])
         else:
             payload = None
         return {"type": "log", "message": None, "payload": payload}
@@ -93,7 +94,7 @@ def parse_response(gdb_mi_text: str) -> Dict:
     elif _GDB_MI_TARGET_OUTPUT_RE.match(gdb_mi_text):
         match = _GDB_MI_TARGET_OUTPUT_RE.match(gdb_mi_text)
         if match:
-            payload = match.groups()[0]
+            payload = unescape(match.groups()[0])
         else:
             payload = None
         return {"type": "target", "message": None, "payload": payload}

--- a/tests/test_pygdbmi.py
+++ b/tests/test_pygdbmi.py
@@ -96,6 +96,58 @@ class TestPyGdbMi(unittest.TestCase):
             },
         )
 
+        # Test errors
+        assert_match(
+            parse_response(r'^error,msg="some message"'),
+            {
+                "type": "result",
+                "message": "error",
+                "payload": {"msg": "some message"},
+                "token": None,
+            },
+        )
+        assert_match(
+            parse_response(r'^error,msg="some message",code="undefined-command"'),
+            {
+                "type": "result",
+                "message": "error",
+                "payload": {"msg": "some message", "code": "undefined-command"},
+                "token": None,
+            },
+        )
+        assert_match(
+            parse_response(r'^error,msg="message\twith\nescapes"'),
+            {
+                "type": "result",
+                "message": "error",
+                "payload": {"msg": "message\twith\nescapes"},
+                "token": None,
+            },
+        )
+        assert_match(
+            parse_response(r'^error,msg="This is a double quote: <\">"'),
+            {
+                "type": "result",
+                "message": "error",
+                "payload": {"msg": 'This is a double quote: <">'},
+                "token": None,
+            },
+        )
+        assert_match(
+            parse_response(
+                r'^error,msg="This is a double quote: <\">",code="undefined-command"'
+            ),
+            {
+                "type": "result",
+                "message": "error",
+                "payload": {
+                    "msg": 'This is a double quote: <">',
+                    "code": "undefined-command",
+                },
+                "token": None,
+            },
+        )
+
         # Test a real world Dictionary
         assert_match(
             parse_response(

--- a/tests/test_pygdbmi.py
+++ b/tests/test_pygdbmi.py
@@ -252,7 +252,7 @@ class TestPyGdbMi(unittest.TestCase):
                 {
                     "message": None,
                     "type": "console",
-                    "payload": u"0x00007fe2c5c58920 in __nanosleep_nocancel () at ../sysdeps/unix/syscall-template.S:81\\n",
+                    "payload": "0x00007fe2c5c58920 in __nanosleep_nocancel () at ../sysdeps/unix/syscall-template.S:81\\n",
                     "stream": stream,
                 },
             )
@@ -262,7 +262,7 @@ class TestPyGdbMi(unittest.TestCase):
                     responses[71],
                     {
                         "stream": stream,
-                        "message": u"done",
+                        "message": "done",
                         "type": "result",
                         "payload": None,
                         "token": None,
@@ -273,7 +273,7 @@ class TestPyGdbMi(unittest.TestCase):
                     {
                         "message": None,
                         "type": "output",
-                        "payload": u"The inferior program printed this! Can you still parse it?",
+                        "payload": "The inferior program printed this! Can you still parse it?",
                         "stream": stream,
                     },
                 )
@@ -281,9 +281,9 @@ class TestPyGdbMi(unittest.TestCase):
                 responses[137],
                 {
                     "stream": stream,
-                    "message": u"thread-group-exited",
+                    "message": "thread-group-exited",
                     "type": "notify",
-                    "payload": {u"exit-code": u"0", u"id": u"i1"},
+                    "payload": {"exit-code": "0", "id": "i1"},
                     "token": None,
                 },
             )
@@ -291,9 +291,9 @@ class TestPyGdbMi(unittest.TestCase):
                 responses[138],
                 {
                     "stream": stream,
-                    "message": u"thread-group-started",
+                    "message": "thread-group-started",
                     "type": "notify",
-                    "payload": {u"pid": u"48337", u"id": u"i1"},
+                    "payload": {"pid": "48337", "id": "i1"},
                     "token": None,
                 },
             )
@@ -301,9 +301,9 @@ class TestPyGdbMi(unittest.TestCase):
                 responses[139],
                 {
                     "stream": stream,
-                    "message": u"tsv-created",
+                    "message": "tsv-created",
                     "type": "notify",
-                    "payload": {u"name": "trace_timestamp", u"initial": "0"},
+                    "payload": {"name": "trace_timestamp", "initial": "0"},
                     "token": None,
                 },
             )
@@ -311,9 +311,9 @@ class TestPyGdbMi(unittest.TestCase):
                 responses[140],
                 {
                     "stream": stream,
-                    "message": u"tsv-created",
+                    "message": "tsv-created",
                     "type": "notify",
-                    "payload": {u"name": "trace_timestamp", u"initial": "0"},
+                    "payload": {"name": "trace_timestamp", "initial": "0"},
                     "token": None,
                 },
             )

--- a/tests/test_pygdbmi.py
+++ b/tests/test_pygdbmi.py
@@ -56,25 +56,25 @@ class TestPyGdbMi(unittest.TestCase):
             parse_response('~""'), {"type": "console", "payload": "", "message": None}
         )
         assert_match(
-            parse_response('~"\b\f\n\r\t""'),
+            parse_response(r'~"\b\f\n\r\t\""'),
             {"type": "console", "payload": '\b\f\n\r\t"', "message": None},
         )
         assert_match(
             parse_response('@""'), {"type": "target", "payload": "", "message": None}
         )
         assert_match(
-            parse_response('@"\b\f\n\r\t""'),
+            parse_response(r'@"\b\f\n\r\t\""'),
             {"type": "target", "payload": '\b\f\n\r\t"', "message": None},
         )
         assert_match(
             parse_response('&""'), {"type": "log", "payload": "", "message": None}
         )
         assert_match(
-            parse_response('&"\b\f\n\r\t""'),
+            parse_response(r'&"\b\f\n\r\t\""'),
             {"type": "log", "payload": '\b\f\n\r\t"', "message": None},
         )
         assert_match(
-            parse_response('&"\\"'), {"type": "log", "payload": "\\", "message": None}
+            parse_response(r'&"\\"'), {"type": "log", "payload": "\\", "message": None}
         )  # test that an escaped backslash gets captured
 
         # Test that a dictionary with repeated keys (a gdb bug) is gracefully worked-around  by pygdbmi


### PR DESCRIPTION
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

This PR changes how escaped strings are dealt with:
- Escaped strings in error messages were previously mangled (except for `'\"'`) but are now unescaped correctly. Fixes #57.
- Escaped strings in all textual records were left unchanged but are now unescaped correctly. Fixes #58.
- This PR also adds soem testing for error records (which were previously untested) so I could test my fix.
- All strings in the form `u"..."` in `tests/test_pygdbmi.py` were changed to drop the `u`. This is irrelevant for the bugs I was fixing but black insisted on it, see the commit message for the relevant commit.

## Test plan

Initially I tested the fix manually like this:
```
$ python3 -c $'from pygdbmi import gdbmiparser; print(gdbmiparser.parse_response(r\'~"a\\nb"\')["payload"])'
a
b

$ python3 -c $'from pygdbmi import gdbmiparser; print(gdbmiparser.parse_response(r\'^error,msg="a\\nb",foo="bar"\')["payload"]["msg"])'
a
b
```

Then I added automated tests which can be run with `nox -s tests`.


While tests work correctly locally, I couldn't run the automated checks on GitHub because GitHub says:
> **1 workflow awaiting approval**
> First-time contributors need a maintainer to approve running workflows. [Learn more](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks).