### PR TITLE
Drop support for Python 3.6 and add explicit support for 3.9 and 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        # Keep the version here in sync with the ones used in noxfile.py
+        python-version: ["3.7", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +42,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -57,7 +58,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev
 * Strings containing escapes are now unescaped, both for messages in error records, which were previously mangled (#57), and textual records, which were previously left escaped (#58)
+* Dropped support for Python 3.6 and added explicit support for Python 3.9 and 3.10.
 
 ## 0.10.0.1
 * Fix bug with `time_to_check_for_additional_output_sec`, as it was not being used when passed to `GdbController`

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,10 @@ nox.options.sessions = ["tests", "lint", "docs"]
 nox.options.reuse_existing_virtualenvs = True
 
 
-@nox.session(python=["3.6", "3.7", "3.8"])
+# Run tests with (at least) the oldest and newest versions we support.
+# If these are modified, also modify .github/workflows/tests.yml and the list of supported versions
+# in setup.py.
+@nox.session(python=["3.7", "3.10"])
 def tests(session):
     session.install(".", "pytest")
     session.run("pytest", *session.posargs)

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,12 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+        # If modifying the list of supported versions, also update the versions pygdbmi is tested
+        # with, see noxfile.py and .github/workflows/tests.yml.
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
 )


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

Run tests, both locally and on GitHub, using Python 3.9 and 3.10 as well.
When doing `nox -s tests` locally only available Python versions are used so this PR doesn't require users to install more Python version.

Note that I changed the yaml file to use quotes around Python versions so they are not interpreted as numbers (otherwise 3.10 becomes 3.1...).

## Test plan
I ran all tests locally (where I made sure I have all the versions available) with:
```
nox -s tests
```

Moreover, this PR makes sure the tests are also run on GitHub.