### PR TITLE
Fix: notifications without payload are not recognized as notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # pygdbmi release history
 
+## 0.10.0.3
+* Fixed a bug where notifications without a payload were not recognized as such
+
 ## 0.10.0.2
 * Strings containing escapes are now unescaped, both for messages in error records, which were previously mangled (#57), and textual records, which were previously left escaped (#58)
 * Dropped support for Python 3.6 and added explicit support for Python 3.9 and 3.10.

--- a/pygdbmi/gdbmiparser.py
+++ b/pygdbmi/gdbmiparser.py
@@ -149,14 +149,14 @@ def assert_match(actual_char_or_str, expected_char_or_str):
 # In addition to a number of out-of-band notifications,
 # the response to a gdb/mi command includes one of the following result indications:
 # done, running, connected, error, exit
-_GDB_MI_RESULT_RE = re.compile(r"^(\d*)\^(\S+?)(,(.*))?$")
+_GDB_MI_RESULT_RE = re.compile(r"^(\d*)\^(\S+?)(,.*)?$")
 
 # https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Async-Records.html#GDB_002fMI-Async-Records
 # Async records are used to notify the gdb/mi client of additional
 # changes that have occurred. Those changes can either be a consequence
 # of gdb/mi commands (e.g., a breakpoint modified) or a result of target activity
 # (e.g., target stopped).
-_GDB_MI_NOTIFY_RE = re.compile(r"^(\d*)[*=](\S+?)(,(.*))*$")
+_GDB_MI_NOTIFY_RE = re.compile(r"^(\d*)[*=](\S+?)(,.*)*$")
 
 # https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Stream-Records.html#GDB_002fMI-Stream-Records
 # "~" string-output
@@ -194,7 +194,7 @@ _GDB_MI_VALUE_START_CHARS = [
 def _get_notify_msg_and_payload(result, stream: StringStream):
     """Get notify message and payload dict"""
     match = _GDB_MI_NOTIFY_RE.match(result)
-    groups = match.groups() if match else [""]
+    groups = match.groups()
     token = int(groups[0]) if groups[0] != "" else None
     message = groups[1]
 
@@ -214,7 +214,7 @@ def _get_result_msg_and_payload(result, stream: StringStream):
     """Get result message and payload dict"""
 
     match = _GDB_MI_RESULT_RE.match(result)
-    groups = match.groups() if match else [""]
+    groups = match.groups()
     token = int(groups[0]) if groups[0] != "" else None
     message = groups[1]
 

--- a/pygdbmi/gdbmiparser.py
+++ b/pygdbmi/gdbmiparser.py
@@ -194,6 +194,7 @@ _GDB_MI_VALUE_START_CHARS = [
 def _get_notify_msg_and_payload(result, stream: StringStream):
     """Get notify message and payload dict"""
     match = _GDB_MI_NOTIFY_RE.match(result)
+    assert match is not None
     groups = match.groups()
     token = int(groups[0]) if groups[0] != "" else None
     message = groups[1]
@@ -212,8 +213,8 @@ def _get_notify_msg_and_payload(result, stream: StringStream):
 
 def _get_result_msg_and_payload(result, stream: StringStream):
     """Get result message and payload dict"""
-
     match = _GDB_MI_RESULT_RE.match(result)
+    assert match is not None
     groups = match.groups()
     token = int(groups[0]) if groups[0] != "" else None
     message = groups[1]

--- a/tests/test_pygdbmi.py
+++ b/tests/test_pygdbmi.py
@@ -194,6 +194,27 @@ class TestPyGdbMi(unittest.TestCase):
             },
         )
 
+        # Test async records status changes
+        assert_match(
+            parse_response('*running,thread-id="all"'),
+            {
+                "type": "notify",
+                "payload": {"thread-id": "all"},
+                "message": "running",
+                "token": None,
+            },
+        )
+
+        assert_match(
+            parse_response('*stopped'),
+            {
+                "type": "notify",
+                "payload": None,
+                "message": "stopped",
+                "token": None,
+            },
+        )
+
     def _get_c_program(self, makefile_target_name, binary_name):
         """build c program and return path to binary"""
         find_executable(MAKE_CMD)

--- a/tests/test_pygdbmi.py
+++ b/tests/test_pygdbmi.py
@@ -206,7 +206,7 @@ class TestPyGdbMi(unittest.TestCase):
         )
 
         assert_match(
-            parse_response('*stopped'),
+            parse_response("*stopped"),
             {
                 "type": "notify",
                 "payload": None,


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes
Changed the regex and extraction of gdbmi async records to factor in notifications without payloads. This occurs e.g. when attaching to a running process, see async record at the end:

```
C:\temp>gdb --interpreter=mi2
=thread-group-added,id="i1"
~"GNU gdb (GDB) 7.6.1\n"
~"Copyright (C) 2013 Free Software Foundation, Inc.\n"
~"License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.  Type \"show copying\"\nand \"show warranty\" for details.\n"
~"This GDB was configured as \"mingw32\".\nFor bug reporting instructions, please see:\n"
~"<http://www.gnu.org/software/gdb/bugs/>.\n"
(gdb)
-target-attach 11708
=thread-group-started,id="i1",pid="11708"
=thread-created,id="1",group-id="i1"
~"[New Thread 11708.0x1a54]\n"
^running
*running,thread-id="all"
(gdb)
=thread-created,id="2",group-id="i1"
~"[New Thread 11708.0x36c0]\n"
*running,thread-id="all"
=thread-created,id="3",group-id="i1"
~"[New Thread 11708.0x3d78]\n"
*running,thread-id="all"
=library-loaded,id="C:\\WINDOWS\\SYSTEM32\\ntdll.dll",target-name="C:\\WINDOWS\\SYSTEM32\\ntdll.dll",host-name="C:\\WINDOWS\\SYSTEM32\\ntdll.dll",symbols-loaded="0",thread-group="i1"
=library-loaded,id="C:\\WINDOWS\\System32\\kernel32.dll",target-name="C:\\WINDOWS\\System32\\kernel32.dll",host-name="C:\\WINDOWS\\System32\\kernel32.dll",symbols-loaded="0",thread-group="i1"
=library-loaded,id="C:\\WINDOWS\\System32\\KernelBase.dll",target-name="C:\\WINDOWS\\System32\\KernelBase.dll",host-name="C:\\WINDOWS\\System32\\KernelBase.dll",symbols-loaded="0",thread-group="i1"
=library-loaded,id="C:\\WINDOWS\\System32\\msvcrt.dll",target-name="C:\\WINDOWS\\System32\\msvcrt.dll",host-name="C:\\WINDOWS\\System32\\msvcrt.dll",symbols-loaded="0",thread-group="i1"
*stopped
(gdb)
```

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
https://github.com/H0bo/pygdbmi/actions/runs/2488322734
