### PR TITLE
Do not raise a UnicodeDecodeError for invalid octal escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.0.3
 * Fixed a bug where notifications without a payload were not recognized as such
+* Invalid octal sequences produced by GDB are left unchanged instead of causing a `UnicodeDecodeError` (#64)
 
 ## 0.10.0.2
 * Strings containing escapes are now unescaped, both for messages in error records, which were previously mangled (#57), and textual records, which were previously left escaped (#58)

--- a/pygdbmi/gdbescapes.py
+++ b/pygdbmi/gdbescapes.py
@@ -166,7 +166,13 @@ def _unescape_internal(
                     raise ValueError(
                         f"Invalid octal number {octal_number!r} in {escaped_str!r}"
                     ) from exc
-            replaced = octal_sequence_bytes.decode("utf-8")
+            try:
+                replaced = octal_sequence_bytes.decode("utf-8")
+            except UnicodeDecodeError:
+                # GDB should never generate invalid sequences but, according to #64,
+                # it can do that on Windows. In this case we just keep the sequence
+                # unchanged.
+                replaced = f"\\{escaped_octal}"
 
         elif escaped_char is not None:
             # We found a single escaped character.

--- a/tests/test_pygdbmi.py
+++ b/tests/test_pygdbmi.py
@@ -502,6 +502,9 @@ class TestGdbEscapes(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "Invalid escape character"):
                 unescape(bad)
 
+        # An octal sequence that is not valid UTF-8 doesn't get changes, see #64.
+        assert_match(unescape(r"254 '\376'"), r"254 '\376'")
+
     def test_advance_past_string_with_gdb_escapes(self) -> None:
         """Test the advance_past_string_with_gdb_escapes function"""
 


### PR DESCRIPTION
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

According to #64, GDB on Windows can produce invalid octal sequences. I cannot reproduce the problem (and I don't have access to Windows) but, instead of failing, we are better off by just allowing the string to be unchanged. 

Fixes https://github.com/cs01/pygdbmi/issues/64

## Test plan
Added a test case and tested by running
```
nox -s tests
```
