### PR TITLE
Refactor MI parsing to decrease the number of regex matches to perform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 Internal changes
 
 - Update and freeze dependencies for documentation generation
+- Refactored the code to parse MI records to decrease the number of regex matches to perform
 
 ## 0.10.0.2
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

The previous code to match MI records used to do matches twice. This PR simplifies the code (hopefully!) and means that matches need to happen only once.
Functionally, there should be no changes as I kept the regexes mostly identical and the same checks are executed in the same order.
“Mostly” because tokens used to be matched with `(\d*)` and are now matched with `(\d+)?` which I think makes it clearer to readers of the code that tokens are optional.

## Test plan
Tested by running
```
nox -s tests
```