### PR TITLE
Rename IoManager.make_non_blocking to be private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## dev
 
+**Breaking changes**
+
+- Removed `pygdbmi.IoManager.make_non_blocking` from the public API; it's unrelated and was not meant to be public
+
+Other changes
+
 - Fixed a bug where notifications without a payload were not recognized as such
 - Invalid octal sequences produced by GDB are left unchanged instead of causing a `UnicodeDecodeError` (#64)
 

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -25,10 +25,7 @@ else:
     import fcntl
 
 
-__all__ = [
-    "IoManager",
-    "make_non_blocking",
-]
+__all__ = ["IoManager"]
 
 
 logger = logging.getLogger(__name__)
@@ -68,9 +65,9 @@ class IoManager:
         self._allow_overwrite_timeout_times = (
             self.time_to_check_for_additional_output_sec > 0
         )
-        make_non_blocking(self.stdout)
+        _make_non_blocking(self.stdout)
         if self.stderr:
-            make_non_blocking(self.stderr)
+            _make_non_blocking(self.stderr)
 
     def get_gdb_response(
         self, timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC, raise_error_on_timeout=True
@@ -325,7 +322,7 @@ def _buffer_incomplete_responses(
     return (raw_output, buf)
 
 
-def make_non_blocking(file_obj: io.IOBase):
+def _make_non_blocking(file_obj: io.IOBase):
     """make file object non-blocking
     Windows doesn't have the fcntl module, but someone on
     stack overflow supplied this code as an answer, and it works


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

`make_non_blocking` is currently public and has a docstring (so it appears in the docs) but I think it may have been exposed by mistake as it seems unrelated to the main goals of pygdbmi.
Moreover, it's likely that fixing https://github.com/cs01/pygdbmi/issues/54 will mean removing it.

## Test plan
Tested by running
```
nox -s tests
```
