### PR TITLE
Use isort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Internal changes
 - Refactored the code to parse MI records to decrease the number of regex matches to perform
 - Added `__all__` to all modules, which means that star imports (like `from pygdbmi.gdbmiparser import *`) will not pollute the namespace with modules used by pygdbmi itself
 - Added `nox -s format` to re-format the source code using the correct options
+- Reformatted all imports with `isort`, and use it as part of `nox -s lint` and `nox -s format`
 
 ## 0.10.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Internal changes
 - Update and freeze dependencies for documentation generation
 - Refactored the code to parse MI records to decrease the number of regex matches to perform
 - Added `__all__` to all modules, which means that star imports (like `from pygdbmi.gdbmiparser import *`) will not pollute the namespace with modules used by pygdbmi itself
+- Added `nox -s format` to re-format the source code using the correct options
 
 ## 0.10.0.2
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ nox -s tests
 nox -s lint
 ```
 
+To format code using the correct settings use
+
+```
+nox -s format
+```
+
+Or, to format only specified files, use
+
+```
+nox -s format -- example.py pygdbmi/IoManager.py
+```
+
 ## Similar projects
 
 - [tsgdbmi](https://github.com/Guyutongxue/tsgdbmi) A port of pygdbmi to TypeScript

--- a/example.py
+++ b/example.py
@@ -3,11 +3,13 @@
 """
 Run with `python -m example`
 """
-import subprocess
 import os
+import subprocess
 import sys
-from pygdbmi.gdbcontroller import GdbController
 from distutils.spawn import find_executable
+
+from pygdbmi.gdbcontroller import GdbController
+
 
 SAMPLE_C_CODE_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "tests", "sample_c_app"

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,6 +26,8 @@ LINTED_PATHS = set(
     )
 )
 
+ISORT_OPTIONS = ["--profile", "black", "--lines-after-imports", "2"]
+
 
 # `format` is a builtin so the function is named differently.
 @nox.session(name="format")
@@ -37,13 +39,15 @@ def format_(session):
         # Only use positional arguments which are linted files.
         files = files & {str(Path(f).resolve()) for f in session.posargs}
 
-    session.install("black", "flake8", "mypy", "check-manifest")
+    session.install("isort", "black", "flake8", "mypy", "check-manifest")
+    session.run("isort", *ISORT_OPTIONS, *files)
     session.run("black", *files)
 
 
 @nox.session()
 def lint(session):
-    session.install(*["black", "flake8", "mypy", "check-manifest"])
+    session.install("isort", "black", "flake8", "mypy", "check-manifest")
+    session.run("isort", "--check-only", *ISORT_OPTIONS, *LINTED_PATHS)
     session.run("black", "--check", *LINTED_PATHS)
     session.run("flake8", *LINTED_PATHS)
     session.run("mypy", *LINTED_PATHS)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,9 @@
 import itertools
-import nox  # type: ignore
-from pathlib import Path
 import shutil
+from pathlib import Path
+
+import nox  # type: ignore
+
 
 nox.options.sessions = ["tests", "lint", "docs"]
 nox.options.reuse_existing_virtualenvs = True

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -3,13 +3,14 @@ which manages I/O for file objects connected to an existing gdb process
 or pty.
 """
 import io
+import logging
+import os
 import select
 import time
 from pprint import pformat
-from typing import Union, List, Optional, Dict, Any, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
+
 from pygdbmi import gdbmiparser
-import os
-import logging
 from pygdbmi.constants import (
     DEFAULT_GDB_TIMEOUT_SEC,
     DEFAULT_TIME_TO_CHECK_FOR_ADDITIONAL_OUTPUT_SEC,
@@ -17,10 +18,11 @@ from pygdbmi.constants import (
     GdbTimeoutError,
 )
 
+
 if USING_WINDOWS:
     import msvcrt
-    from ctypes import windll, byref, wintypes, WinError, POINTER  # type: ignore
-    from ctypes.wintypes import HANDLE, DWORD, BOOL
+    from ctypes import POINTER, WinError, byref, windll, wintypes  # type: ignore
+    from ctypes.wintypes import BOOL, DWORD, HANDLE
 else:
     import fcntl
 

--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -6,12 +6,13 @@ structured output.
 import logging
 import subprocess
 from distutils.spawn import find_executable
-from typing import Union, List, Optional
-from pygdbmi.IoManager import IoManager
+from typing import List, Optional, Union
+
 from pygdbmi.constants import (
     DEFAULT_GDB_TIMEOUT_SEC,
     DEFAULT_TIME_TO_CHECK_FOR_ADDITIONAL_OUTPUT_SEC,
 )
+from pygdbmi.IoManager import IoManager
 
 
 __all__ = ["GdbController"]

--- a/pygdbmi/gdbmiparser.py
+++ b/pygdbmi/gdbmiparser.py
@@ -12,9 +12,9 @@ import logging
 import re
 from typing import Callable, Dict, List, Match, Optional, Pattern, Tuple, Union
 
+from pygdbmi.gdbescapes import unescape
 from pygdbmi.printcolor import fmt_green
 from pygdbmi.StringStream import StringStream
-from pygdbmi.gdbescapes import unescape
 
 
 __all__ = [

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from codecs import open
 
 from setuptools import find_packages, setup  # type: ignore
 
+
 EXCLUDE_FROM_PACKAGES = ["tests"]
 CURDIR = os.path.abspath(os.path.dirname(__file__))
 README = io.open("README.md", "r", encoding="utf-8").read()

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,3 +1,4 @@
-from . import test_pygdbmi, static_tests
+from . import static_tests, test_pygdbmi
+
 
 exit(test_pygdbmi.main() + static_tests.main())

--- a/tests/test_pygdbmi.py
+++ b/tests/test_pygdbmi.py
@@ -8,16 +8,17 @@ Run from top level directory: ./tests/test_app.py
 
 import os
 import random
-import unittest
 import subprocess
-from time import time
+import unittest
 from distutils.spawn import find_executable
 from pprint import pprint
-from pygdbmi.StringStream import StringStream
+from time import time
+
+from pygdbmi.constants import USING_WINDOWS, GdbTimeoutError
+from pygdbmi.gdbcontroller import GdbController
 from pygdbmi.gdbescapes import advance_past_string_with_gdb_escapes, unescape
 from pygdbmi.gdbmiparser import parse_response
-from pygdbmi.gdbcontroller import GdbController
-from pygdbmi.constants import GdbTimeoutError, USING_WINDOWS
+from pygdbmi.StringStream import StringStream
 
 
 if USING_WINDOWS:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

This PR add [`isort`](https://pycqa.github.io/isort/) to the list of linting tools to keep imports grouped and sorted consistently.

To make life easier (as you now need to run both `isort` and `black` to format) I added `nox - s format` to apply both tools in the correct order (`isort` must be applied fist).

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s tests
```
