### PR TITLE
Wait for the GDB process to exit in GdbController.exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Other changes
 
 - Fixed a bug where notifications without a payload were not recognized as such
 - Invalid octal sequences produced by GDB are left unchanged instead of causing a `UnicodeDecodeError` (#64)
+- Fix a crash on Windows by waiting for the GDB process to exit in `GdbController.exit`
 
 Internal changes
 

--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -126,6 +126,7 @@ class GdbController:
         """Terminate gdb process"""
         if self.gdb_process:
             self.gdb_process.terminate()
+            self.gdb_process.wait()
             self.gdb_process.communicate()
         self.gdb_process = None
         return None


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

This fixes a crash on Windows by waiting for the GDB process to exit in `GdbController.exit`.
Original patch by matkuki (see PR https://github.com/cs01/pygdbmi/pull/68), modified by me.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s tests
```
