### PR TITLE
Update Python examples in `README.md` (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Other changes
 - Fixed a bug where notifications without a payload were not recognized as such
 - Invalid octal sequences produced by GDB are left unchanged instead of causing a `UnicodeDecodeError` (#64)
 - Fix a crash on Windows by waiting for the GDB process to exit in `GdbController.exit`
+- Updated the examples in `README.md` to use the current API and show the results printed by this version of pygdbmi (#69)
 
 Internal changes
 

--- a/README.md
+++ b/README.md
@@ -79,19 +79,22 @@ from pygdbmi import gdbmiparser
 from pprint import pprint
 response = gdbmiparser.parse_response('^done,bkpt={number="1",type="breakpoint",disp="keep", enabled="y",addr="0x08048564",func="main",file="myprog.c",fullname="/home/myprog.c",line="68",thread-groups=["i1"],times="0"')
 pprint(response)
-> {'message': 'done',
-'payload': {'bkpt': {'addr': '0x08048564',
-                      'disp': 'keep',
-                      'enabled': 'y',
-                      'file': 'myprog.c',
-                      'fullname': '/home/myprog.c',
-                      'func': 'main',
-                      'line': '68',
-                      'number': '1',
-                      'thread-groups': ['i1'],
-                      'times': '0',
-                      'type': 'breakpoint'}},
- 'type': 'result'}
+pprint(response)
+# Prints:
+# {'message': 'done',
+#  'payload': {'bkpt': {'addr': '0x08048564',
+#                       'disp': 'keep',
+#                       'enabled': 'y',
+#                       'file': 'myprog.c',
+#                       'fullname': '/home/myprog.c',
+#                       'func': 'main',
+#                       'line': '68',
+#                       'number': '1',
+#                       'thread-groups': ['i1'],
+#                       'times': '0',
+#                       'type': 'breakpoint'}},
+#  'token': None,
+#  'type': 'result'}
 ```
 
 ## Programmatic Control Over gdb
@@ -104,15 +107,21 @@ from pprint import pprint
 
 # Start gdb process
 gdbmi = GdbController()
-print(gdbmi.get_subprocess_cmd())  # print actual command run as subprocess
-
+print(gdbmi.command)  # print actual command run as subprocess
 # Load binary a.out and get structured response
 response = gdbmi.write('-file-exec-file a.out')
 pprint(response)
-[{'message': u'thread-group-added',
-  'payload': {u'id': u'i1'},
-  'type': 'notify'},
- {'message': u'done', 'payload': None, 'type': 'result'}]
+# Prints:
+# [{'message': 'thread-group-added',
+#   'payload': {'id': 'i1'},
+#   'stream': 'stdout',
+#   'token': None,
+#   'type': 'notify'},
+#  {'message': 'done',
+#   'payload': None,
+#   'stream': 'stdout',
+#   'token': None,
+#   'type': 'result'}]
 ```
 
 Now do whatever you want with gdb. All gdb commands, as well as gdb [machine interface commands](<(https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Input-Syntax.html#GDB_002fMI-Input-Syntax)>) are acceptable. gdb mi commands give better structured output that is machine readable, rather than gdb console output. mi commands begin with a `-`.


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

One of the examples in `README.md` used to use `get_subprocess_cmd` which was removed in [449080a084583dc6ee6fd066d453072cf1ed065f](https://github.com/cs01/pygdbmi/commit/449080a084583dc6ee6fd066d453072cf1ed065f).
While fixing that I re-ran the examples and noticed that some output fields changed, so I fixed that too.
I also added `>>> ` before commands in examples where there is some output printed to make it clearer what is a command and what is output.

Fixes #69

## Test plan
Tested by running
```
nox -s test
nox -s lint
```
No extra testing neeed.