### PR TITLE
Run mypy in a stricter configuration and address missing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Other changes
 - Fixed a bug where notifications without a payload were not recognized as such
 - Invalid octal sequences produced by GDB are left unchanged instead of causing a `UnicodeDecodeError` (#64)
 - Fix a crash on Windows by waiting for the GDB process to exit in `GdbController.exit`
+- Added type annotations to the whole public API
 - Updated the examples in `README.md` to use the current API and show the results printed by this version of pygdbmi (#69)
 
 Internal changes
@@ -21,6 +22,7 @@ Internal changes
 - Added `nox -s format` to re-format the source code using the correct options
 - Reformatted all imports with `isort`, and use it as part of `nox -s lint` and `nox -s format`
 - Converted tests to use pytest's test structure rather than the unittest-based one
+- Added mypy configuration to detect more problems and to force all code to be annotated
 - Excluded some common backup and cache files from `MANIFEST.in` to prevent unwanted files to be included which causes `check-manifest` to fail
 
 ## 0.10.0.2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ exclude .flake8
 exclude noxfile.py
 exclude mkdocs.yml
 exclude __pycache__
+exclude mypy.ini
 exclude *.in
 exclude *.txt
 exclude *.pyc

--- a/example.py
+++ b/example.py
@@ -25,14 +25,13 @@ else:
     MAKE_CMD = "make"
 
 
-def main(verbose=True):
+def main() -> None:
     """Build and debug an application programatically
 
     For a list of GDB MI commands, see https://www.sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI.html
     """
 
     # Build C program
-    find_executable(MAKE_CMD)
     if not find_executable(MAKE_CMD):
         print(
             'Could not find executable "%s". Ensure it is installed and on your $PATH.'
@@ -42,7 +41,7 @@ def main(verbose=True):
     subprocess.check_output([MAKE_CMD, "-C", SAMPLE_C_CODE_DIR, "--quiet"])
 
     # Initialize object that manages gdb subprocess
-    gdbmi = GdbController(verbose=verbose)
+    gdbmi = GdbController()
 
     # Send gdb commands. Gdb machine interface commands are easier to script around,
     # hence the name "machine interface".

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+python_version = 3.7
+show_error_codes = True
+warn_redundant_casts = True
+strict_equality = True
+disallow_untyped_defs = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,8 @@ import itertools
 import shutil
 from pathlib import Path
 
-import nox  # type: ignore
+import nox
+from nox.sessions import Session
 
 
 nox.options.sessions = ["tests", "lint", "docs"]
@@ -13,7 +14,7 @@ nox.options.reuse_existing_virtualenvs = True
 # If these are modified, also modify .github/workflows/tests.yml and the list of supported versions
 # in setup.py.
 @nox.session(python=["3.7", "3.10"])
-def tests(session):
+def tests(session: Session) -> None:
     session.install(".", "pytest")
     session.run("pytest", *session.posargs)
 
@@ -33,7 +34,7 @@ ISORT_OPTIONS = ["--profile", "black", "--lines-after-imports", "2"]
 
 # `format` is a builtin so the function is named differently.
 @nox.session(name="format")
-def format_(session):
+def format_(session: Session) -> None:
     """Re-format all Python source files or, if positionals are passed, only the
     specified files."""
     files = LINTED_PATHS
@@ -47,7 +48,7 @@ def format_(session):
 
 
 @nox.session()
-def lint(session):
+def lint(session: Session) -> None:
     session.install(
         # Packages needed as they are used directly.
         "black",
@@ -56,6 +57,7 @@ def lint(session):
         "isort",
         "mypy",
         # Packages needed to provide types for mypy.
+        "nox",
         "pytest",
     )
     session.run("isort", "--check-only", *ISORT_OPTIONS, *LINTED_PATHS)
@@ -66,30 +68,30 @@ def lint(session):
     session.run("python", "setup.py", "check", "--metadata", "--strict")
 
 
-def install_mkdoc_dependencies(session):
+def install_mkdoc_dependencies(session: Session) -> None:
     session.install("-r", "mkdoc_requirements.txt")
 
 
 @nox.session
-def docs(session):
+def docs(session: Session) -> None:
     install_mkdoc_dependencies(session)
     session.run("mkdocs", "build")
 
 
 @nox.session
-def serve_docs(session):
+def serve_docs(session: Session) -> None:
     install_mkdoc_dependencies(session)
     session.run("mkdocs", "serve")
 
 
 @nox.session
-def publish_docs(session):
+def publish_docs(session: Session) -> None:
     install_mkdoc_dependencies(session)
     session.run("mkdocs", "gh-deploy")
 
 
 @nox.session(python="3.7")
-def build(session):
+def build(session: Session) -> None:
     session.install("setuptools", "wheel", "twine")
     shutil.rmtree("dist", ignore_errors=True)
     shutil.rmtree("build", ignore_errors=True)
@@ -98,7 +100,7 @@ def build(session):
 
 
 @nox.session(python="3.7")
-def publish(session):
+def publish(session: Session) -> None:
     build(session)
     print("REMINDER: Has the changelog been updated?")
     session.run("python", "-m", "twine", "upload", "dist/*")

--- a/pygdbmi/StringStream.py
+++ b/pygdbmi/StringStream.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from pygdbmi.gdbescapes import advance_past_string_with_gdb_escapes
 
 
@@ -13,12 +15,12 @@ class StringStream:
     to the project.
     """
 
-    def __init__(self, raw_text, debug=False):
+    def __init__(self, raw_text: str, debug: bool = False) -> None:
         self.raw_text = raw_text
         self.index = 0
         self.len = len(raw_text)
 
-    def read(self, count):
+    def read(self, count: int) -> str:
         """Read count characters starting at self.index,
         and return those characters as a string
         """
@@ -31,11 +33,11 @@ class StringStream:
 
         return buf
 
-    def seek(self, offset):
+    def seek(self, offset: int) -> None:
         """Advance the index of this StringStream by offset characters"""
         self.index = self.index + offset
 
-    def advance_past_chars(self, chars):
+    def advance_past_chars(self, chars: List[str]) -> str:
         """Advance the index past specific chars
         Args chars (list): list of characters to advance past
 

--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -6,7 +6,7 @@ structured output.
 import logging
 import subprocess
 from distutils.spawn import find_executable
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from pygdbmi.constants import (
     DEFAULT_GDB_TIMEOUT_SEC,
@@ -26,8 +26,8 @@ class GdbController:
     def __init__(
         self,
         command: Optional[List[str]] = None,
-        time_to_check_for_additional_output_sec=DEFAULT_TIME_TO_CHECK_FOR_ADDITIONAL_OUTPUT_SEC,
-    ):
+        time_to_check_for_additional_output_sec: float = DEFAULT_TIME_TO_CHECK_FOR_ADDITIONAL_OUTPUT_SEC,
+    ) -> None:
         """
         Run gdb as a subprocess. Send commands and receive structured output.
         Create new object, along with a gdb subprocess
@@ -48,11 +48,11 @@ class GdbController:
                 + "See https://sourceware.org/gdb/onlinedocs/gdb/Mode-Options.html#Mode-Options."
             )
         self.abs_gdb_path = None  # abs path to gdb executable
-        self.command = command  # type: List[str]
+        self.command: List[str] = command
         self.time_to_check_for_additional_output_sec = (
             time_to_check_for_additional_output_sec
         )
-        self.gdb_process = None
+        self.gdb_process: Optional[subprocess.Popen] = None
         self._allow_overwrite_timeout_times = (
             self.time_to_check_for_additional_output_sec > 0
         )
@@ -72,7 +72,7 @@ class GdbController:
 
         self.spawn_new_gdb_subprocess()
 
-    def spawn_new_gdb_subprocess(self):
+    def spawn_new_gdb_subprocess(self) -> int:
         """Spawn a new gdb subprocess with the arguments supplied to the object
         during initialization. If gdb subprocess already exists, terminate it before
         spanwing a new one.
@@ -96,6 +96,8 @@ class GdbController:
             bufsize=0,
         )
 
+        assert self.gdb_process.stdin is not None
+        assert self.gdb_process.stdout is not None
         self.io_manager = IoManager(
             self.gdb_process.stdin,
             self.gdb_process.stdout,
@@ -105,18 +107,20 @@ class GdbController:
         return self.gdb_process.pid
 
     def get_gdb_response(
-        self, timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC, raise_error_on_timeout=True
-    ):
+        self,
+        timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
+        raise_error_on_timeout: bool = True,
+    ) -> List[Dict]:
         """Get gdb response. See IoManager.get_gdb_response() for details"""
         return self.io_manager.get_gdb_response(timeout_sec, raise_error_on_timeout)
 
     def write(
         self,
         mi_cmd_to_write: Union[str, List[str]],
-        timeout_sec=DEFAULT_GDB_TIMEOUT_SEC,
+        timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
         read_response: bool = True,
-    ):
+    ) -> List[Dict]:
         """Write command to gdb. See IoManager.write() for details"""
         return self.io_manager.write(
             mi_cmd_to_write, timeout_sec, raise_error_on_timeout, read_response

--- a/pygdbmi/gdbmiparser.py
+++ b/pygdbmi/gdbmiparser.py
@@ -10,7 +10,7 @@ See more at https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI.html#GDB_002fMI
 import functools
 import logging
 import re
-from typing import Callable, Dict, List, Match, Optional, Pattern, Tuple, Union
+from typing import Any, Callable, Dict, List, Match, Optional, Pattern, Tuple, Union
 
 from pygdbmi.gdbescapes import unescape
 from pygdbmi.printcolor import fmt_green
@@ -27,7 +27,7 @@ _DEBUG = False
 logger = logging.getLogger(__name__)
 
 
-def _setup_logger(logger, debug):
+def _setup_logger(logger: logging.Logger, debug: bool) -> None:
     logger.propagate = False
 
     handler = logging.StreamHandler()
@@ -91,7 +91,7 @@ def response_is_finished(gdb_mi_text: str) -> bool:
 # ========================================================================
 
 
-def _parse_mi_notify(match: Match, stream: StringStream):
+def _parse_mi_notify(match: Match, stream: StringStream) -> Dict:
     """Parser function for matches against a notify record.
 
     See _GDB_MI_PATTERNS_AND_PARSERS for details."""
@@ -107,7 +107,7 @@ def _parse_mi_notify(match: Match, stream: StringStream):
     }
 
 
-def _parse_mi_result(match: Match, stream: StringStream):
+def _parse_mi_result(match: Match, stream: StringStream) -> Dict:
     """Parser function for matches against a result record.
 
     See _GDB_MI_PATTERNS_AND_PARSERS for details."""
@@ -119,7 +119,7 @@ def _parse_mi_result(match: Match, stream: StringStream):
     }
 
 
-def _parse_mi_output(match: Match, stream: StringStream, output_type: str):
+def _parse_mi_output(match: Match, stream: StringStream, output_type: str) -> Dict:
     """Parser function for matches against a console, log or target record.
 
     The record type must be specified in output_type.
@@ -132,7 +132,7 @@ def _parse_mi_output(match: Match, stream: StringStream, output_type: str):
     }
 
 
-def _parse_mi_finished(match: Match, stream: StringStream):
+def _parse_mi_finished(match: Match, stream: StringStream) -> Dict:
     """Parser function for matches against a finished record.
 
     See _GDB_MI_PATTERNS_AND_PARSERS for details."""
@@ -247,13 +247,13 @@ _GDB_MI_VALUE_START_CHARS = [
 ]
 
 
-def _parse_dict(stream: StringStream):
+def _parse_dict(stream: StringStream) -> Dict:
     """Parse dictionary, with optional starting character '{'
     return (tuple):
         Number of characters parsed from to_parse
         Parsed dictionary
     """
-    obj: Dict[str, Union[str, list]] = {}
+    obj: Dict[str, Union[str, list, dict]] = {}
 
     logger.debug("%s", fmt_green("parsing dict"))
 
@@ -305,7 +305,7 @@ def _parse_dict(stream: StringStream):
     return obj
 
 
-def _parse_key_val(stream: StringStream):
+def _parse_key_val(stream: StringStream) -> Tuple[str, Union[str, List, Dict]]:
     """Parse key, value combination
     return (tuple):
         Parsed key (string)
@@ -323,7 +323,7 @@ def _parse_key_val(stream: StringStream):
     return key, val
 
 
-def _parse_key(stream: StringStream):
+def _parse_key(stream: StringStream) -> str:
     """Parse key, value combination
     returns :
         Parsed key (string)
@@ -337,13 +337,15 @@ def _parse_key(stream: StringStream):
     return key
 
 
-def _parse_val(stream: StringStream):
+def _parse_val(stream: StringStream) -> Union[str, List, Dict]:
     """Parse value from string
     returns:
         Parsed value (either a string, array, or dict)
     """
 
     logger.debug("parsing value")
+
+    val: Any
 
     while True:
         c = stream.read(1)
@@ -376,7 +378,7 @@ def _parse_val(stream: StringStream):
     return val
 
 
-def _parse_array(stream: StringStream):
+def _parse_array(stream: StringStream) -> list:
     """Parse an array, stream should be passed the initial [
     returns:
         Parsed array

--- a/pygdbmi/printcolor.py
+++ b/pygdbmi/printcolor.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 
 __all__ = [
@@ -13,35 +14,35 @@ __all__ = [
 USING_WINDOWS = os.name == "nt"
 
 
-def print_red(x):
+def print_red(x: Any) -> None:
     if USING_WINDOWS:
         print(x)
     else:
         print("\033[91m {}\033[00m".format(x))
 
 
-def print_green(x):
+def print_green(x: Any) -> None:
     if USING_WINDOWS:
         print(x)
     else:
         print("\033[92m {}\033[00m".format(x))
 
 
-def print_cyan(x):
+def print_cyan(x: Any) -> None:
     if USING_WINDOWS:
         print(x)
     else:
         print("\033[96m {}\033[00m".format(x))
 
 
-def fmt_green(x):
+def fmt_green(x: Any) -> str:
     if USING_WINDOWS:
         return x
     else:
         return "\033[92m {}\033[00m".format(x)
 
 
-def fmt_cyan(x):
+def fmt_cyan(x: Any) -> str:
     if USING_WINDOWS:
         return x
     else:


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

This PR adds some stricter configuration to mypy and fix issues found by mypy. This should guarantee that the whole codebase is always fully type checked and that our public API is not missing any type annotation.

Noe that this PR doesn't touch the `tests/` directory as that was rewritten in https://github.com/cs01/pygdbmi/pull/81. This means that linting is currently failing. As the other PR has full type annotations, this can go in after the other one is merged.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s tests
nox -s lint  # Read comment above about thi currently failing
```
