### PR TITLE
Exclude some backup, cache, etc. files from the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Internal changes
 - Added `__all__` to all modules, which means that star imports (like `from pygdbmi.gdbmiparser import *`) will not pollute the namespace with modules used by pygdbmi itself
 - Added `nox -s format` to re-format the source code using the correct options
 - Reformatted all imports with `isort`, and use it as part of `nox -s lint` and `nox -s format`
+- Excluded some common backup and cache files from `MANIFEST.in` to prevent unwanted files to be included which causes `check-manifest` to fail
 
 ## 0.10.0.2
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,8 +7,12 @@ exclude example.py
 exclude .flake8
 exclude noxfile.py
 exclude mkdocs.yml
+exclude __pycache__
 exclude *.in
 exclude *.txt
+exclude *.pyc
+exclude *.sw[po]
+exclude *~
 
 prune tests
 prune docs


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

I use `vim` which produces files like `*~` (backup) and `*.swp`/`*.swo` (to restore files). Morover, Python produces `*.pyc` files and `__pycache__` directories when run. These are included when preparing the package for pygdbmi which causes `check-manifest` to fail.
By ignoring these files, the problem should go away.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s tests
nox -s lint
```
