### PR TITLE
Run pyupgrade on the whole codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Internal changes
 - Converted tests to use pytest's test structure rather than the unittest-based one
 - Added mypy configuration to detect more problems and to force all code to be annotated
 - Added a test for `example.py`
+- Ran [`pyupgrade`](https://github.com/asottile/pyupgrade) (with option `--py37-plus`) on the codebase to convert to Python 3.7 idioms
 - Excluded some common backup and cache files from `MANIFEST.in` to prevent unwanted files to be included which causes `check-manifest` to fail
 
 ## 0.10.0.2

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ def tests(session: Session) -> None:
     session.run("pytest", *session.posargs)
 
 
-LINTED_PATHS = set(
+LINTED_PATHS = {
     str(p.resolve())
     for p in itertools.chain(
         # All top-level Python files.
@@ -27,7 +27,7 @@ LINTED_PATHS = set(
         # Plus Python files in these specified directories.
         *(Path(d).glob("**/*.py") for d in ("pygdbmi", "tests"))
     )
-)
+}
 
 ISORT_OPTIONS = ["--profile", "black", "--lines-after-imports", "2"]
 

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -118,7 +118,7 @@ class IoManager:
                 self.stdout.flush()
                 raw_output = self.stdout.readline().replace(b"\r", b"\n")
                 responses_list = self._get_responses_list(raw_output, "stdout")
-            except IOError:
+            except OSError:
                 pass
 
             if self.stderr is not None:
@@ -126,7 +126,7 @@ class IoManager:
                     self.stderr.flush()
                     raw_output = self.stderr.readline().replace(b"\r", b"\n")
                     responses_list += self._get_responses_list(raw_output, "stderr")
-                except IOError:
+                except OSError:
                     pass
 
             responses += responses_list

--- a/pygdbmi/printcolor.py
+++ b/pygdbmi/printcolor.py
@@ -18,32 +18,32 @@ def print_red(x: Any) -> None:
     if USING_WINDOWS:
         print(x)
     else:
-        print("\033[91m {}\033[00m".format(x))
+        print(f"\033[91m {x}\033[00m")
 
 
 def print_green(x: Any) -> None:
     if USING_WINDOWS:
         print(x)
     else:
-        print("\033[92m {}\033[00m".format(x))
+        print(f"\033[92m {x}\033[00m")
 
 
 def print_cyan(x: Any) -> None:
     if USING_WINDOWS:
         print(x)
     else:
-        print("\033[96m {}\033[00m".format(x))
+        print(f"\033[96m {x}\033[00m")
 
 
 def fmt_green(x: Any) -> str:
     if USING_WINDOWS:
         return x
     else:
-        return "\033[92m {}\033[00m".format(x)
+        return f"\033[92m {x}\033[00m"
 
 
 def fmt_cyan(x: Any) -> str:
     if USING_WINDOWS:
         return x
     else:
-        return "\033[96m {}\033[00m".format(x)
+        return f"\033[96m {x}\033[00m"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import io
 import os
 import re
 from codecs import open
@@ -10,9 +9,9 @@ from setuptools import find_packages, setup  # type: ignore
 
 EXCLUDE_FROM_PACKAGES = ["tests"]
 CURDIR = os.path.abspath(os.path.dirname(__file__))
-README = io.open("README.md", "r", encoding="utf-8").read()
+README = open("README.md", encoding="utf-8").read()
 
-with open("pygdbmi/__init__.py", "r") as fd:
+with open("pygdbmi/__init__.py") as fd:
     matches = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
     )

--- a/tests/test_gdbcontroller.py
+++ b/tests/test_gdbcontroller.py
@@ -85,7 +85,7 @@ def test_controller() -> None:
     got_no_process_exception = False
     try:
         responses = gdbmi.write("-file-exec-and-symbols %s" % c_hello_world_binary)
-    except IOError:
+    except OSError:
         got_no_process_exception = True
     assert got_no_process_exception is True
 

--- a/tests/test_gdbescapes.py
+++ b/tests/test_gdbescapes.py
@@ -9,7 +9,7 @@ from pygdbmi.gdbescapes import advance_past_string_with_gdb_escapes, unescape
 # Split a Unicode character into its UTF-8 bytes and encode each one as a 3-digit
 # oct char prefixed with a "\".
 # This is the opposite of what the gdbescapes module does.
-GDB_ESCAPED_PIZZA = "".join(rf"\{c:03o}" for c in "\N{SLICE OF PIZZA}".encode("utf-8"))
+GDB_ESCAPED_PIZZA = "".join(rf"\{c:03o}" for c in "\N{SLICE OF PIZZA}".encode())
 # Similar but for a simple space.
 # This character was chosen because, in octal, it's shorter than three digits, so we
 # can check that unescape_gdb_mi_string handles the initial `0` correctly.


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

I ran [`pyupgrade`](url) on the whole codebase to convert to Python 3.7 idioms:
```
pyupgrade --py37-plus $(find . -name '*.py')
```

It's not big changes but at least it converts some strings to format strings.

Note that this tool is not suitable to be run during the linting phase as it doesn't have a `--check` or similar option.

## Test plan
Tested by running
```
nox -s tests
nox -s lint
```
