### PR TITLE
Use shutil.which instead of distutils.spawn.find_executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Internal changes
 - Converted tests to use pytest's test structure rather than the unittest-based one
 - Added mypy configuration to detect more problems and to force all code to be annotated
 - Added a test for `example.py`
+- Replaced uses of `distutils.spawn.find_executable`, which is deprecated, with `shutil.which`
 - Ran [`pyupgrade`](https://github.com/asottile/pyupgrade) (with option `--py37-plus`) on the codebase to convert to Python 3.7 idioms
 - Excluded some common backup and cache files from `MANIFEST.in` to prevent unwanted files to be included which causes `check-manifest` to fail
 

--- a/example.py
+++ b/example.py
@@ -4,9 +4,9 @@
 Run with `python -m example`
 """
 import os
+import shutil
 import subprocess
 import sys
-from distutils.spawn import find_executable
 
 from pygdbmi.gdbcontroller import GdbController
 
@@ -32,7 +32,7 @@ def main() -> None:
     """
 
     # Build C program
-    if not find_executable(MAKE_CMD):
+    if not shutil.which(MAKE_CMD):
         print(
             'Could not find executable "%s". Ensure it is installed and on your $PATH.'
             % MAKE_CMD

--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -4,8 +4,8 @@ structured output.
 """
 
 import logging
+import shutil
 import subprocess
-from distutils.spawn import find_executable
 from typing import Dict, List, Optional, Union
 
 from pygdbmi.constants import (
@@ -61,7 +61,7 @@ class GdbController:
             raise ValueError("a valid path to gdb must be specified")
 
         else:
-            abs_gdb_path = find_executable(gdb_path)
+            abs_gdb_path = shutil.which(gdb_path)
             if abs_gdb_path is None:
                 raise ValueError(
                     'gdb executable could not be resolved from "%s"' % gdb_path

--- a/tests/test_gdbcontroller.py
+++ b/tests/test_gdbcontroller.py
@@ -7,8 +7,8 @@ Run from top level directory: ./tests/test_app.py
 
 import os
 import random
+import shutil
 import subprocess
-from distutils.spawn import find_executable
 
 import pytest
 
@@ -24,7 +24,7 @@ else:
 
 def _get_c_program(makefile_target_name: str, binary_name: str) -> str:
     """build c program and return path to binary"""
-    if not find_executable(MAKE_CMD):
+    if not shutil.which(MAKE_CMD):
         raise AssertionError(
             'Could not find executable "%s". Ensure it is installed and on your $PATH.'
             % MAKE_CMD


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

`distutils.spawn.find_executable` is deprecated and is going to be removed in Python 3.12 so this PR replaces it with `shutil.which` (which behaves the same).

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s tests
nox -s lint
```
