### PR TITLE
Add a test for example.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Internal changes
 - Reformatted all imports with `isort`, and use it as part of `nox -s lint` and `nox -s format`
 - Converted tests to use pytest's test structure rather than the unittest-based one
 - Added mypy configuration to detect more problems and to force all code to be annotated
+- Added a test for `example.py`
 - Excluded some common backup and cache files from `MANIFEST.in` to prevent unwanted files to be included which causes `check-manifest` to fail
 
 ## 0.10.0.2

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,6 @@
+import example
+
+
+def test_example() -> None:
+    """Test `example.py` in the root of the repo"""
+    example.main()


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

Previosuly, `example.py` was not working due to passing a non-existing argument to `GdbController`. This was noticed when we started running mypy in stricter mode.
This PR adds a very basic test which runs the example and, at least, it makes sure no exception is raised.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s tests
nox -s lint
```

Added `tests/test_example.py`.