### PR TITLE
Add pwndbg-gui to list of projects that use pygdbmi

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ To make a release:
 - [PINCE](https://github.com/korcankaraokcu/PINCE) is a gdb frontend that aims to provide a reverse engineering tool and a reusable library focused on games. It uses pygdbmi to parse gdb/mi based output for some functions
 - [avatar²](https://github.com/avatartwo/avatar2) is an orchestration framework for reversing and analysing firmware of embedded devices. It utilizes pygdbmi for internal communication to different analysis targets.
 - [UDB](https://undo.io/udb) is a proprietary time-travel debugger for C and C++ based on GDB. It uses pygdbmi in its extensive test suite to parse the debugger's output.
+- [pwndbg-gui](https://github.com/AlEscher/pwndbg-gui) is a user-friendly graphical interface for [pwndbg](https://github.com/pwndbg/pwndbg), a tool that simplifies exploit development and reverse engineering with GDB. It uses pygdbmi to interact with GDB and get structured responses.
 - Know of another project? Create a PR and add it here.
 
 ## Authors


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- ~~[ ] I have added an entry to `CHANGELOG.md`~~ (Not added as it does not seem relevant enough)

## Summary of changes
Added [pwndbg-gui](https://github.com/AlEscher/pwndbg-gui) to the list of projects that use pygdbmi.

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
# The lint cmd gave "would reformat pygdbmi/pygdbmi/IoManager.py", however since no changes were made to that file in this PR I will leave it as is
nox -s tests
nox -s lint
```
