### PR TITLE
Xtyll/return on first response

### DIFF
--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -109,7 +109,9 @@ class IoManager:
         else:
             return retval
 
-    def _get_responses_windows(self, timeout_sec: float, return_on_first_response: bool) -> List[Dict]:
+    def _get_responses_windows(
+        self, timeout_sec: float, return_on_first_response: bool
+    ) -> List[Dict]:
         """Get responses on windows. Assume no support for select and use a while loop."""
         timeout_time_sec = time.time() + timeout_sec
         responses = []
@@ -145,7 +147,9 @@ class IoManager:
 
         return responses
 
-    def _get_responses_unix(self, timeout_sec: float, return_on_first_response: bool) -> List[Dict]:
+    def _get_responses_unix(
+        self, timeout_sec: float, return_on_first_response: bool
+    ) -> List[Dict]:
         """Get responses on unix-like system. Use select to wait for output."""
         timeout_time_sec = time.time() + timeout_sec
         responses = []
@@ -201,7 +205,10 @@ class IoManager:
         """
         responses: List[Dict[Any, Any]] = []
 
-        (_new_output, self._incomplete_output[stream],) = _buffer_incomplete_responses(
+        (
+            _new_output,
+            self._incomplete_output[stream],
+        ) = _buffer_incomplete_responses(
             raw_output, self._incomplete_output.get(stream)
         )
 
@@ -232,7 +239,7 @@ class IoManager:
         timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
         read_response: bool = True,
-        return_on_first_response: bool = False
+        return_on_first_response: bool = False,
     ) -> List[Dict]:
         """Write to gdb process. Block while parsing responses from gdb for a maximum of timeout_sec.
 
@@ -289,7 +296,7 @@ class IoManager:
             return self.get_gdb_response(
                 timeout_sec=timeout_sec,
                 raise_error_on_timeout=raise_error_on_timeout,
-                return_on_first_response=return_on_first_response
+                return_on_first_response=return_on_first_response,
             )
 
         else:

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -74,6 +74,7 @@ class IoManager:
         self,
         timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
+        return_on_first_response: bool = False,
     ) -> List[Dict]:
         """Get response from GDB, and block while doing so. If GDB does not have any response ready to be read
         by timeout_sec, an exception is raised.
@@ -96,9 +97,9 @@ class IoManager:
             timeout_sec = 0
 
         if USING_WINDOWS:
-            retval = self._get_responses_windows(timeout_sec)
+            retval = self._get_responses_windows(timeout_sec, return_on_first_response)
         else:
-            retval = self._get_responses_unix(timeout_sec)
+            retval = self._get_responses_unix(timeout_sec, return_on_first_response)
 
         if not retval and raise_error_on_timeout:
             raise GdbTimeoutError(
@@ -108,7 +109,7 @@ class IoManager:
         else:
             return retval
 
-    def _get_responses_windows(self, timeout_sec: float) -> List[Dict]:
+    def _get_responses_windows(self, timeout_sec: float, return_on_first_response: bool) -> List[Dict]:
         """Get responses on windows. Assume no support for select and use a while loop."""
         timeout_time_sec = time.time() + timeout_sec
         responses = []
@@ -132,6 +133,8 @@ class IoManager:
             responses += responses_list
             if timeout_sec == 0:
                 break
+            elif return_on_first_response is True and responses:
+                break
             elif responses_list and self._allow_overwrite_timeout_times:
                 timeout_time_sec = min(
                     time.time() + self.time_to_check_for_additional_output_sec,
@@ -142,7 +145,7 @@ class IoManager:
 
         return responses
 
-    def _get_responses_unix(self, timeout_sec: float) -> List[Dict]:
+    def _get_responses_unix(self, timeout_sec: float, return_on_first_response: bool) -> List[Dict]:
         """Get responses on unix-like system. Use select to wait for output."""
         timeout_time_sec = time.time() + timeout_sec
         responses = []
@@ -174,7 +177,8 @@ class IoManager:
 
             if timeout_sec == 0:  # just exit immediately
                 break
-
+            elif return_on_first_response is True and responses:
+                break
             elif responses_list and self._allow_overwrite_timeout_times:
                 # update timeout time to potentially be closer to now to avoid lengthy wait times when nothing is being output by gdb
                 timeout_time_sec = min(
@@ -228,6 +232,7 @@ class IoManager:
         timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
         read_response: bool = True,
+        return_on_first_response: bool = False
     ) -> List[Dict]:
         """Write to gdb process. Block while parsing responses from gdb for a maximum of timeout_sec.
 
@@ -282,7 +287,9 @@ class IoManager:
 
         if read_response is True:
             return self.get_gdb_response(
-                timeout_sec=timeout_sec, raise_error_on_timeout=raise_error_on_timeout
+                timeout_sec=timeout_sec,
+                raise_error_on_timeout=raise_error_on_timeout,
+                return_on_first_response=return_on_first_response
             )
 
         else:

--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -110,9 +110,10 @@ class GdbController:
         self,
         timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
+        return_on_first_response: bool = False
     ) -> List[Dict]:
         """Get gdb response. See IoManager.get_gdb_response() for details"""
-        return self.io_manager.get_gdb_response(timeout_sec, raise_error_on_timeout)
+        return self.io_manager.get_gdb_response(timeout_sec, raise_error_on_timeout, return_on_first_response)
 
     def write(
         self,
@@ -120,10 +121,15 @@ class GdbController:
         timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
         read_response: bool = True,
+        return_on_first_response: bool = False
     ) -> List[Dict]:
         """Write command to gdb. See IoManager.write() for details"""
         return self.io_manager.write(
-            mi_cmd_to_write, timeout_sec, raise_error_on_timeout, read_response
+            mi_cmd_to_write=mi_cmd_to_write,
+            timeout_sec=timeout_sec,
+            raise_error_on_timeout=raise_error_on_timeout,
+            read_response=read_response,
+            return_on_first_response=return_on_first_response
         )
 
     def exit(self) -> None:

--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -110,10 +110,12 @@ class GdbController:
         self,
         timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
-        return_on_first_response: bool = False
+        return_on_first_response: bool = False,
     ) -> List[Dict]:
         """Get gdb response. See IoManager.get_gdb_response() for details"""
-        return self.io_manager.get_gdb_response(timeout_sec, raise_error_on_timeout, return_on_first_response)
+        return self.io_manager.get_gdb_response(
+            timeout_sec, raise_error_on_timeout, return_on_first_response
+        )
 
     def write(
         self,
@@ -121,7 +123,7 @@ class GdbController:
         timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
         read_response: bool = True,
-        return_on_first_response: bool = False
+        return_on_first_response: bool = False,
     ) -> List[Dict]:
         """Write command to gdb. See IoManager.write() for details"""
         return self.io_manager.write(
@@ -129,7 +131,7 @@ class GdbController:
             timeout_sec=timeout_sec,
             raise_error_on_timeout=raise_error_on_timeout,
             read_response=read_response,
-            return_on_first_response=return_on_first_response
+            return_on_first_response=return_on_first_response,
         )
 
     def exit(self) -> None:

--- a/tests/test_gdbcontroller.py
+++ b/tests/test_gdbcontroller.py
@@ -9,6 +9,7 @@ import os
 import random
 import shutil
 import subprocess
+import time
 
 import pytest
 
@@ -95,6 +96,26 @@ def test_controller() -> None:
         "-file-exec-and-symbols %s" % c_hello_world_binary, timeout_sec=1
     )
     responses = gdbmi.write(["-break-insert main", "-exec-run"])
+
+
+def test_return_on_first_response() -> None:
+    gdbmi = GdbController(time_to_check_for_additional_output_sec=0)
+    c_hello_world_binary = _get_c_program("hello", "pygdbmiapp.a")
+
+    if USING_WINDOWS:
+        c_hello_world_binary = c_hello_world_binary.replace("\\", "/")
+    # Load the binary and its symbols in the gdb subprocess
+    responses = gdbmi.write(
+        "-file-exec-and-symbols %s" % c_hello_world_binary, timeout_sec=1
+    )
+    responses = gdbmi.write(
+        "-file-exec-and-symbols %s" % c_hello_world_binary, timeout_sec=1
+    )
+    timeout_sec = 10.0
+    start_time = time.time()
+    responses = gdbmi.write("stepi", timeout_sec=timeout_sec, return_on_first_response=True)
+    endtime = time.time()
+    assert(start_time + timeout_sec > endtime)
 
 
 @pytest.mark.skip()


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [] I have added parameter `return_on_first_response` to write and get_response methods. With this parameter GbdController return the first received response without adidtional waiting

## Summary of changes

## Test plan
<!-- provide evidence of testing, preferably with command(s) that can be copy+pasted by others -->
Tested by running
```
nox -s tests
```
The separate test added (`test_return_on_first_response`). The test set timeout to 10s without additional delay and perform one simple `stepi` operation. To test pass we expect that response will generated faster than defined timeout

