### PR TITLE
Increase test timeout duration for RISC-V

### DIFF
--- a/example.py
+++ b/example.py
@@ -49,7 +49,7 @@ def main() -> None:
     # Responses are returned after writing, by default.
 
     # Load the file
-    responses = gdbmi.write("-file-exec-and-symbols %s" % SAMPLE_C_BINARY)
+    responses = gdbmi.write("-file-exec-and-symbols %s" % SAMPLE_C_BINARY, timeout_sec=10)
     # Get list of source files used to compile the binary
     responses = gdbmi.write("-file-list-exec-source-files")
     # Add breakpoint

--- a/tests/test_gdbcontroller.py
+++ b/tests/test_gdbcontroller.py
@@ -92,7 +92,7 @@ def test_controller() -> None:
     # Respawn and test signal handling
     gdbmi.spawn_new_gdb_subprocess()
     responses = gdbmi.write(
-        "-file-exec-and-symbols %s" % c_hello_world_binary, timeout_sec=1
+        "-file-exec-and-symbols %s" % c_hello_world_binary, timeout_sec=10
     )
     responses = gdbmi.write(["-break-insert main", "-exec-run"])
 


### PR DESCRIPTION
Test fails on RISC-V because it is a very slow architecture: fix this by increasing the timeout on this specific test.

Error messages:
```
example.py:52: in main
    responses = gdbmi.write("-file-exec-and-symbols %s" % SAMPLE_C_BINARY)
pygdbmi/gdbcontroller.py:125: in write
    return self.io_manager.write(
pygdbmi/IoManager.py:284: in write
    return self.get_gdb_response(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pygdbmi.IoManager.IoManager object at 0x3feb1bbe10>, timeout_sec = 1
raise_error_on_timeout = True

    def get_gdb_response(
        self,
        timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
        raise_error_on_timeout: bool = True,
    ) -> List[Dict]:
        """Get response from GDB, and block while doing so. If GDB does not have any response ready to be read
        by timeout_sec, an exception is raised.
    
        Args:
            timeout_sec: Maximum time to wait for reponse. Must be >= 0. Will return after
            raise_error_on_timeout: Whether an exception should be raised if no response was found after timeout_sec
    
        Returns:
            List of parsed GDB responses, returned from gdbmiparser.parse_response, with the
            additional key 'stream' which is either 'stdout' or 'stderr'
    
        Raises:
            GdbTimeoutError: if response is not received within timeout_sec
            ValueError: if select returned unexpected file number
        """
    
        if timeout_sec < 0:
            logger.warning("timeout_sec was negative, replacing with 0")
            timeout_sec = 0
    
        if USING_WINDOWS:
            retval = self._get_responses_windows(timeout_sec)
        else:
            retval = self._get_responses_unix(timeout_sec)
    
        if not retval and raise_error_on_timeout:
>           raise GdbTimeoutError(
                "Did not get response from gdb after %s seconds" % timeout_sec
            )
E           pygdbmi.constants.GdbTimeoutError: Did not get response from gdb after 1 seconds

pygdbmi/IoManager.py:104: GdbTimeoutError
```