### PR TITLE
Add return_on_result flag, to return immediately when a result is received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## <0.11.0.1>.dev0
 
 - *Replace this line with new entries*
+- Added a flag `return_on_result`, which causes an immediate return when a response of type 'result' is received,
+instead of waiting until the timeout passes.
 
 ## 0.11.0.0
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,13 +7,13 @@ exclude example.py
 exclude .flake8
 exclude noxfile.py
 exclude mkdocs.yml
-exclude __pycache__
+global-exclude __pycache__
 exclude mypy.ini
 exclude *.in
 exclude *.txt
-exclude *.pyc
-exclude *.sw[po]
-exclude *~
+global-exclude *.pyc
+global-exclude *.sw[po]
+global-exclude *~
 
 prune tests
 prune docs

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -197,7 +197,10 @@ class IoManager:
         """
         responses: List[Dict[Any, Any]] = []
 
-        (_new_output, self._incomplete_output[stream],) = _buffer_incomplete_responses(
+        (
+            _new_output,
+            self._incomplete_output[stream],
+        ) = _buffer_incomplete_responses(
             raw_output, self._incomplete_output.get(stream)
         )
 

--- a/pygdbmi/IoManager.py
+++ b/pygdbmi/IoManager.py
@@ -205,7 +205,11 @@ class IoManager:
             if timeout_sec == 0:  # just exit immediately
                 break
 
-            elif responses_list and self._allow_overwrite_timeout_times:
+            elif (
+                responses_list
+                and self._allow_overwrite_timeout_times
+                and not return_on_result
+            ):
                 # update timeout time to potentially be closer to now to avoid lengthy wait times when nothing is being output by gdb
                 timeout_time_sec = min(
                     time.time() + self.time_to_check_for_additional_output_sec,

--- a/pygdbmi/gdbcontroller.py
+++ b/pygdbmi/gdbcontroller.py
@@ -110,20 +110,28 @@ class GdbController:
         self,
         timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
+        return_on_result: bool = False,
     ) -> List[Dict]:
         """Get gdb response. See IoManager.get_gdb_response() for details"""
-        return self.io_manager.get_gdb_response(timeout_sec, raise_error_on_timeout)
+        return self.io_manager.get_gdb_response(
+            timeout_sec, raise_error_on_timeout, return_on_result
+        )
 
     def write(
         self,
         mi_cmd_to_write: Union[str, List[str]],
         timeout_sec: float = DEFAULT_GDB_TIMEOUT_SEC,
         raise_error_on_timeout: bool = True,
+        return_on_result: bool = False,
         read_response: bool = True,
     ) -> List[Dict]:
         """Write command to gdb. See IoManager.write() for details"""
         return self.io_manager.write(
-            mi_cmd_to_write, timeout_sec, raise_error_on_timeout, read_response
+            mi_cmd_to_write,
+            timeout_sec,
+            raise_error_on_timeout,
+            return_on_result,
+            read_response,
         )
 
     def exit(self) -> None:

--- a/tests/test_gdbcontroller.py
+++ b/tests/test_gdbcontroller.py
@@ -9,6 +9,7 @@ import os
 import random
 import shutil
 import subprocess
+import time
 
 import pytest
 
@@ -67,6 +68,14 @@ def test_controller() -> None:
     assert response["payload"] == {"id": "i1"}
     assert response["stream"] == "stdout"
     assert response["token"] is None
+
+    # Verify exits quickly if return_on_result is True
+    t0 = time.monotonic()
+    responses = gdbmi.write(["-rubbish"], return_on_result=True)
+    t1 = time.monotonic()
+    duration = t1 - t0
+    assert len(responses) != 0
+    assert duration < 0.01
 
     responses = gdbmi.write(["-file-list-exec-source-files", "-break-insert main"])
     assert len(responses) != 0

--- a/tests/test_gdbcontroller.py
+++ b/tests/test_gdbcontroller.py
@@ -77,6 +77,14 @@ def test_controller() -> None:
     assert len(responses) != 0
     assert duration < 0.01
 
+    # Verify waits for timeout if return_on_result is not set
+    t0 = time.monotonic()
+    responses = gdbmi.write(["-rubbish"])
+    t1 = time.monotonic()
+    duration = t1 - t0
+    assert len(responses) != 0
+    assert duration >= 0.2
+
     responses = gdbmi.write(["-file-list-exec-source-files", "-break-insert main"])
     assert len(responses) != 0
 


### PR DESCRIPTION
<!-- add an 'x' in the brackets below -->
- [x] I have added an entry to `CHANGELOG.md`

## Summary of changes

When I run a command and wait for the response, many times I don't want to wait for the entire timeout. So I added a flag return_on_result, which returns immediately when a response of type 'result' is received.

Notes:
* I made this False by default to preserve backwards compatibility.
* I added this flag to `IoManager.write()` as well, together with `timeout_sec` and `raise_error_on_timeout` which are also passed to `get_gdb_response()`. I added it after `raise_error_on_timeout` and before `read_response`, to keep it with the other `get_gdb_response()` flags. However, this will break code that sets `read_response` as a positional argument (meaning: `iomanager.write('-cmd', timeout, raise_error_on_timeout, read_response)`. I leave it up to you to decide if you prefer better backwards compatibility or a more logical ordering of arguments.
* The first two commits were just to make nox happy. The second commit might actually have some significance - it seems that .pyc files not in the root directory could be included in sdists.

## Test plan
I added an automated test which sets the `return_on_result` flag and makes sure it returns fast. You can see it fail by replacing `True` with `False` in `test_gdbcontroller.py`:

```
    responses = gdbmi.write(["-rubbish"], return_on_result=True)
```
